### PR TITLE
add `CodonVariant.numCodonMutsByType` method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 0.2.dev0
 --------
 
+Added
+-----
+- `CodonVariant.numCodonMutsByType` method to get numerical values for codon mutations per variant.
+
 Fixed
 -----
 - Docs /formatting in Jupyter notebooks.

--- a/notebooks/codonvariant_sim_data.ipynb
+++ b/notebooks/codonvariant_sim_data.ipynb
@@ -675,7 +675,9 @@
    "metadata": {},
    "source": [
     "Average number of codon mutations per variant of each type of codon mutation.\n",
-    "First, for just single-mutant and wildtype variants:"
+    "We make these plots for:\n",
+    " 1. Just single-mutant and wildtype variants\n",
+    " 2. For all variants"
    ]
   },
   {
@@ -698,31 +700,7 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "p = variants.plotNumCodonMutsByType('single', samples=None)\n",
-    "_ = p.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now for variants with any number of mutations:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "attributes": {
-     "classes": [],
-     "id": "",
-     "n": "18"
-    }
-   },
-   "outputs": [
+    },
     {
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAfcAAAFcCAYAAADVrvcKAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3XlcVOX7+P/XMAEqCIIgKu77lua+i6Joai5p4p68TatvWSmaW6aCmlkuSWal5YqpmVq5YyEtmkv5Vltc3m7hwqqAgOzM7w9+zMeRATmzA9fz8eDxcM45c5/rjNfMNXPOfe5bpdFoNAghhBCi1LCzdgBCCCGEMC0p7kIIIUQpI8VdCCGEKGWkuAshhBCljBR3IYQQopSR4i6EEEKUMlLchRBCiFJGirsQQghRykhxF0IIIUqZp6wdgC27cuWKtUMQNqBRo0aFrpMcESA5IopWVH6Yi/xyF0IIIUoZKe5CCCFEKSPFXQghyqjDhw/z2muvaR/36tWLyMhIvdtOnTqV77//HoCjR48SGBhYrOeZSmhoKO+//75Z91GaSHEvQ0aNGsXp06d13iTR0dH06tWLzMxMK0cnbIHkiCgOPz8/Vq5cadF9jhs3jtmzZ1t0nyWZdKgrg8aNG2d0G1lZWSxevJjLly8TExPDsmXL6NChgwmiE7bAFDnyzz//sHHjRm2HsqZNmzJlyhRq1KhhdNui5MrJyUGtVpv9OWWdFHdhsKeffprhw4ezePFia4cibFBycjL9+/dnwYIFODo6smHDBt555x02b95s7dDKlB07drBv3z4SEhLw9PRk4sSJ+Pj4GNXm4cOH+f7771m7dq122e+//86cOXNITk6mR48evPnmmzg4OHDu3DmCg4MZM2YMO3fupG7dunzwwQcsWrSIc+fOkZGRQb169Zg6dSr16tUD4P3338fBwYGEhAR+//13ZsyYwa1bt4iMjGT+/PkAXLp0iU8//ZTr16/j7u7OSy+9RI8ePQA4ffo0n332GdHR0ZQrV46+ffvy6quvGnXMJY2cli+DNm3aRHBwsM6yo0eP4u/vz9ChQ1m/fj25ublFtmFvb88LL7xAy5YtsbOTNCptTJEjHTt2xNfXF2dnZ+zt7fH39ycyMpKkpCRzhi4eU61aNT766CP279/PxIkTWbp0KXFxcSbfT3h4OGvWrGHz5s1cvXqV0NBQ7bqkpCSioqLYtm0bixYtAqBdu3Zs2bKFPXv20KRJE+3yfEePHmXYsGEcPHiQbt266ay7d+8es2bNYsSIEXz77bfMmjWL5cuX8++//wKwbNkyRo0axcGDB9m2bZu26Jcl8qksADh16hSbNm3ik08+4dixYxw+fNjaIQkbY2yOnD9/Hnd3d1xdXc0UodDHx8cHT09P7Ozs8PHxoWbNmvzzzz8m38+YMWNwc3PDzc2NcePG8eOPP+qsnzx5Mg4ODjg6OgLQv39/nJyccHBw4MUXX+TmzZs6X/w6d+5M69atUalU2ufkCwsLo02bNnTr1g21Wk2zZs3o1q0bERERQN6Pjzt37pCUlET58uVp1qyZyY/X1slpeQFAQEAAFSpUoEKFCgwbNowff/yRAQMGWDssYUOMyZG7d+8SEhLClClTzByleNyRI0fYtWsX0dHRAKSlpZnl7EmVKlW0/65atSrx8fHax66urpQrV077OCcnhy+//JKffvqJxMREVCoVkPcLP//Ln5eXV6H7io6O5vjx4zz33HM6bfbt2xeA4OBgQkNDGTduHN7e3kyYMIHOnTub5kBLCCnuAij6jSkEGJ4jsbGxzJgxg1GjRuHr62uu8IQe0dHRLF++nOXLl9OiRQvUajWTJ082y75iY2Np0KABADExMXh4eBS67Y8//sgvv/zChx9+SLVq1UhNTWXQoEE62+QXfH28vLzw9fUttPd8o0aNCA4OJicnh2PHjrFgwQK+++47ypcvb8CRlUxyWl4AeW/MfE96Y4qyyZAciYuLIzAwkOeeew5/f39zhif0SE9PB6BSpUpA3q/4GzdumGVfO3bsIDExkcTEREJDQ+ndu3eh2z58+BB7e3tcXFzIyMhgw4YNivbl5+fH6dOnOXHiBDk5OWRlZfHPP//w77//kpWVRVhYGMnJyajVapydnVGpVGWut70UdwHA5s2befjwIXfv3mXPnj3F+oWVmZmpvfc5OzubzMzMJ3ayEiWX0hyJj49n2rRp+Pn5MWbMGAtFKR5Vp04dRo4cyRtvvMGwYcO4evUqzZs3N8u+evbsyeuvv8748eOpW7dukbdT9uvXj2rVqjFixAgCAgJo3Lixon15enqydOlSvvnmG4YNG8YLL7zAF198QVZWFpB3ZmDs2LEMGDCAdevWsWDBAhwcHIw6vpJGpdFoNNYOwlaVtgkfRo0aRWBgIP/884/2lpLo6GhGjx7NjBkz2Lx5M5mZmQwYMIBJkyY9sRf8qFGjiImJ0Vm2atUqnnnmGXMehsWVpUlBTJkjmzdvZtOmTTrXWiGvJ35R11NLorKUI0I5a0wcI8W9CPKmFCAf3OLJJEdEUWRWOCGEEEIYrcz0ls/KyuKzzz7j/PnzJCcn4+Hhgb+/v9EjNZVmK1eu5OjRowWWt2zZkmXLllkhImFrJEeEsE1l5rR8eno6u3fvpnfv3nh5eXHx4kWCg4NZuHAhTZo00fscOZ0mQE65iieTHBFFkdPyZlSuXDnGjh1L1apVUalUNGvWjKZNm3Lx4kVrhyaEEEKYVJk5Lf+49PR0rl69WmDghEe5u7ubNQaVSkX58uVJS0vDFk+g2Hp8YP0YzZkjarUaNzc3EhISyMnJMdt+jGHrMdpCfGU5R2w9PrBMjKY8e1PcswBlsrjn5uby0Ucf0bBhQ1q3bq1dHh8frzPqlp2dHZ6enmaLQ61WU6FCBbKzs20y8W09PrB+jOYcGCO/bVsefMPWY7SF+Mpyjth6fFAyYjREmbnmnk+j0fDJJ58QGRlJUFCQznCEn3/+OevXr9c+DggIkLGwhRBCGMUav9zLVHHXaDR89tlnXL16lUWLFlGhQgWd9db45e7i4sKDBw9s8pexrccHlonRzc2t0HUJCQlm2SfI628KlopPckQ/W48PLBOjKafYldPyenz++edcvnyZxYsXFyjsAB4eHjrjZcfHx1skIXNycmw28cH24wPrxSj5kcfWY7RmfJIjth8flIwYlVBc3CMjI6lWrRr29vYF1mVnZ3P37l1q1aplkuBMKTY2loMHD2Jvb8/EiRO1y1944QWZ0EIIIUSpori4161bl99++40OHToUWHf+/Hk6dOhgk99+qlSpwvfff2/tMIQQQgizU3yfe1GX6DMyMnB0dDQqICGEEEIYp1i/3C9dusQ///yjfRwREcHt27d1tklPT2f79u3Uq1fPtBEKIYQQQpFiFfedO3cSFBQE5A0aMnv2bL3bVapUiU2bNpksuJJizpw5HDlyhFu3bhEeHs7TTz9dYJvc3FwWLFhAeHg4Tz31FG5ubqxevZq2bdsCEBYWxoIFC8jJyaFZs2Z8/PHHVKxYEYA1a9awc+dOcnNzadCgASEhIbi6ulr0GIUQ5mPuz5B8U6ZMYefOnVy9elU+Q0q5Yp2Wnzp1Kjdu3OD69etoNBr27NnDjRs3dP7u3LnDvXv3GDx4sLljtjmDBg1i//791KxZs9BtDh8+zOnTp4mIiOCnn36ie/fuLFq0CICUlBSmTp3Kli1bOH36NF5eXqxYsQLIO0uyfft2Dh06xPHjx2nZsiVLliyxyHEJ05gzZw5t2rTB09OTP//8U+82X331FT179tT+NW7cmBdffFG7fs2aNXTv3p2uXbsyYcIEkpKStOt27NhBjx496NmzJ7169dI7kYuwbeb8DMm3f/9+vR2hRelUrOLu6upK7dq1qVOnDjdu3GDAgAHUrl1b569atWqoVCpzx2uTunTpQvXq1YvcRqVSkZGRQUZGBhqNhpSUFO1zfvjhB1q0aEHDhg0BmDhxInv27AHg77//pmPHjjg7OwPQp08fdu3aZcajEaZWnA/uMWPGEBERof2rUqUKL7zwAgDHjh0r9AteQkICc+bMYdeuXURERLB06VLefPNNixyXMB1zfoZA3t1CH330kfbLgCj9FPeWr127NgB3797l9u3bpKenF9imR48exkdWyvTr149ff/2V5s2b4+TkRLVq1di/fz8At2/f1vngr1mzJjExMWRnZ9OqVSs2btxITEwMVapUYffu3aSkpJCQkFDkwBnCdnTp0kXR9n/88Qfx8fH0798fgL/++qvAF7yhQ4fywQcfkJubq/2g9/Ly4sGDB1SrVs3kxyCsz9DPkKeeeorAwEAWLFigzSFR+iku7tevX2f8+PGcPHkSKNh7XqVS2eStcNZ27tw5Ll26xIULF6hYsSKLFi1i+vTpfP3110U+r1u3brz22muMHTsWtVrNgAEDAHjqqTI1/lCZsm3bNkaMGKE9hfrMM8+wYcMGvV/wKleuzPLly+nduzdubm6kp6fzzTffWPkIhDkY+hmydetWvL296d69u4UiFbZAcYWYPHkyt2/fZsOGDTRr1gwHBwdzxFXq7Ny5k27dumk7sYwcOVI7eE6NGjU4duyYdttbt27h5eWlLeATJ07UDrzz+++/U7169QIdZUTpkJqayt69ezl8+LB2Wffu3Qv9gvfgwQPWrVtHWFgYjRo14siRIwQEBHD8+HF5b5Yyhn6GHD9+nN9++02nL4aPjw9btmyhZcuWlj0IYTGK73M/ffo0q1atYsKECbRv355WrVoV+BMF1alTh19//ZXMzEwgr2drkyZNAOjduzd//vkn//vf/wDYsGEDzz//vPa50dHRADx8+JBly5bJZDal2Pfff0+TJk1o3LixzvKJEyfyww8/cOTIEbp27ar9ghcREYGrq6t2vOl+/fqRnJzMrVu3rBG+MCNDP0M+++wzzp8/z9mzZzl79iwAP/30kxT2Uk7xL3dvb+9SNzWesaZPn87Ro0eJjY1l5MiRODk5cebMGaZOncqzzz7Ls88+y8SJE7ly5Qo9e/bE3t6eKlWqsHLlSgAqVqzIqlWrePHFF8nOzqZp06asWbNG276/vz+5ublkZmbi7+/PpEmTrHWowsy2bdvGmDFjCiyPjo6matWqBb7g1a5dm7/++ouYmBi8vLw4c+YM2dnZeHt7Wzp0YQRzf4aIskfxrHC7d+9m+fLlHDhwAHd3d3PFZRMenSHOHNRqNW5ubiQkJNhkPwVbjw8sE+Ojkwk9rjg58ugHt7u7u94PboCrV6/Sp08f/vrrL5ydnXWOrWvXrjpf8KZPn669O+Xzzz9ny5Yt2Nvbo1areffdd+nZs6dJjv1JbD1HLBWfsTliKHn9jWeJGO/fv2+ytsw25eugQYM4d+4cSUlJPPPMM1SqVEm3QZWK7777TkmTNquwN2XWfvNNA2so++dMN6VgPnlj5pEP7sLZeoxS3K3L1uOD0lvcFZ+WT0lJoUGDBtrHycnJSpsQotQzxRfALCDK+FAA83z5E8aRHBHmpLi4P9ojUwghhBC2R3FveSGEEELYNoNGQsnNzSU8PJwrV67oHaEuMDDQ6MCEEEIIYRjFxT06OpqePXty5coVVCqVdoS6R8eVLy3F3cHBQe/89KbrGmE65hjUJv//1MnJqcBIhLbC2jE6OTlhZ1fwBJit5Yi5Bj2y9uv/JLYQX1nOEVt4/Z/EEjGaskNdcSku7oGBgVSuXJlbt25Rs2ZNTp06hZeXF6GhoWzZsoUDBw6YI06ryMzM1A4YYevM0bFRrVbj4OBAamqqTfd0NXeM+r7g5UtNTTXLPk3NXB1fbT1HLBWf5Ih+tp4fUDJiNITi4v7zzz8TEhKinZxCo9FQq1Yt5s6di0ajYcqUKRw6dMjkgQohhBCieBR3qEtKSsLT0xM7OztcXFyIjY3VruvcuTO//vqrSQMUQgghhDKKi3vdunWJisq7s7J58+Zs3bpVu27v3r2lftQ6IYQQwtYpPi0/cOBAwsLC8Pf3Z968eQwZMoQqVapgb29PdHQ0y5YtM0ecQgghhCgmxcV96dKl2n/379+fEydOsHfvXtLS0vDz86N///4mDVAIIYQQyhh0n/uj2rVrR7t27UwRixBCCCFMoFjF/f79+1SqVAk7O7ti3a8n192FEEII6ylWcff09OS3336jQ4cOeHh46AxYo09puldQCCGEKGmKVdw3bNhA/fr1Adi4caNZAxJCCCGEcYpV3CdMmABAdnY2Tz/9NDVr1sTT0/bmNBdCCCGEwg51dnZ2dOrUiYMHD9KnTx9zxSSEEEKUCWPGjCnWmPbbt29X1K7i4l6vXj0SEhIU7UQIIYQQBQ0aNIgjR44wZMgQvLy8iI2NZe/evfTr14+GDRsa3K7iW+Hmzp3LokWL6Nq1K9WrVzd4x0IIIURZ98MPP/D+++9TtWpV7bJOnTrxzjvvMGbMGIPbVVzcd+3aRVxcHPXq1aNly5Z4eXnp9J5XqVR89913BgckhBBClBWxsbG4uLjoLHN1ddWZt8UQiot7SkoKTZo00XkshBBCCOXatGnDkiVLmDhxIl5eXsTExPDll1/Stm1bo9pVXNyPHTtm1A5NZf/+/YSHh3Pz5k06d+7M22+/Xei2gwcPxtHRUXuGoVmzZixcuNBCkQohhBD6vf3226xZs4b/9//+H9nZ2djb29OzZ0/efPNNo9o1evjZ4rp//z4RERGcOnWKqKgo0tLSqFy5Mo0bN6Z79+6Kh7B1d3fH39+fc+fOkZyc/MTtV61aRY0aNQwNXwghhDA5Z2dnZs+ezezZs0lMTKRSpUomadeg4p6bm0t4eDhXrlwhPT29wPrAwEDtv3/66SdWr17NgQMHyM7OplatWnh4eODo6MjFixf56quvSElJoU6dOrz00ku88cYbBa4/6NOlSxcArl+/XqziLoQQQtiatLQ0wsLCKF++vElvMVdc3KOjo+nZsydXrlxBpVJp7897tFNdfnHv27cvp0+fZvjw4Xz33Xd07twZV1dXnfY0Gg2XL1/m4MGD7Nixg1WrVrFlyxYGDBhgzHEVMG/ePHJycmjYsCEBAQHUqlXLpO0LIYQQSi1ZsoSoqCiysrK4efMmL7/8MocPH+bMmTO8++67BreruLgHBgZSuXJlbt26Rc2aNTl16hReXl6EhoayZcsWDhw4oN22Z8+e7Nq1q0BBf5RKpaJJkyY0adKEwMBAfvnlFx48eGDY0RTivffeo3HjxmRlZbFnzx7mz5/P2rVrqVChgs528fHxxMfHax/b2dnpHYkvy6TRmYZarTZbm+Zo21SsHWNh+7W1HDHX62Pt1/9JbCG+spwjtvD6P4m1Yzx79iy7du0iOTmZ6dOn8/LLL+Pj48MXX3xhVLuKi/vPP/9MSEgI1apVA/J+edeqVYu5c+ei0WiYMmUKhw4dAvLuiVeqe/fuip/zJC1atADA3t6ecePGcezYMS5evFigN+Lu3btZv3699nFAQABTpkwp0F6UySM0npubm9naLs5lEmuzVoyFve62liPmzA+w/RyxZnySI7afH2DeGOPi4gpd5+rqilqtpmrVqiQlJQF5tSojI8OofSou7klJSXh6emJnZ4eLi4vOvXidO3fm/fffL3ZbN2/e5OrVq7Rp08ai08QWNqvd8OHD8fHx0T62s7MrMaPxmSNOtVqNi4sLDx48sNmZ/iwRY1EfemU5P8D2c8RS8UmO6Gfr+QHWj3HixImsW7eOl156CZVKRUpKCqGhodSrV8+odhUX97p16xIVlfeds3nz5mzdupXnnnsOgL179xZapKdPn05OTg4fffSRdttRo0aRlZWFm5sbYWFhiu7ry8nJIScnh9zcXHJzc8nMzMTOzo6nntI9pMjISLKysqhTpw7Z2dns3r2bzMxMGjduXKBNDw8PPDw8tI/j4+NtNiEfZ844819rW2atGG39dcln7jhtPUesGZ8tvy6Pks8Q68SY/4P422+/RaVSMXjwYOrUqWPU9XYwoLgPHDiQsLAw/P39mTdvHkOGDKFKlSrY29sTHR3NsmXL9D5v7969BAcHax/PnTuXAQMGsGjRIt5++23mzZunPZ1fHDt37mTHjh3ax8ePH8fX15epU6fi7+/PggULaN68OYmJiXz66afEx8fj4OBAgwYNCAoKwtnZWemhCyGEECa1adMm7b9VKhWurq5UrFjR6HZVmuJMR1OE33//nb1795KWloafnx/9+/fXu1358uU5cuQIPXr04Nq1azRs2JAzZ87Qtm1bDh48yIQJE4q8LmENj3aue1TWftub7tb+OdO/dmq1Gjc3NxISEmz2W7clYnz0bM7jSkqOmCM/wPZzxFLxSY7oZ+v5AZaJ8f79+yZrq1GjRsXazuhBbNq1a1esAWgeHSv36NGjuLu7a0/DOzo6kpaWZmwoQgghRIlS2NlugFmzZhncruLiXqtWLUaNGsXo0aNp3bp1sZ/Xo0cP5s+fT0xMDMuXL2fo0KHadZcvX5b7zoUQQpQ5j/dTi46O5uTJk0YPaKO4uPv7+7Njxw5WrFhBw4YNGTNmDKNGjXriqYJVq1Yxfvx4Zs+erR0oP9/WrVvNcgucEEIIYcsmT55cYNn58+fZvXu3Ue3aKX3C8uXLiYyM5NixY/j6+vLJJ5/QtGlT2rZty4oVK7hz547e53l7exMeHk5ycjI//fQTXl5e2nVHjhxhzZo1hh+FEEIIUUq0atWKP/74w6g2FBf3fD169GDt2rXcvXuXQ4cO0bJlSxYvXkydOnX0bu/r68ulS5f0rouOjqZfv36GhiKEEEKUGpmZmdrbxw1ldIc6jUZDZmYmGRkZZGdnU1jn+4iIiEKHlX3w4AE///yzsaEIIYQQJUpubi67d+/mwIEDxMTEUKVKFQYNGsTw4cMLHXCtOAwq7hqNhvDwcHbs2MGePXtISEigffv2LFq0iJEjRxb6vMICPXHiBFWqVDEkFCGEEKLE2rlzJ2FhYUycOBFvb2/u3r3Ll19+SW5uLv7+/ga3q7i4v/nmm3zzzTdER0fTrFkzAgMDGTVqFPXr1y+w7dKlS1m6dCmQV9h79eqFnZ3ulYD8X/yvvfaagYcghBBClEz79+/nvffeo3bt2gDUr1+fWrVq8e6771q2uO/fv5+AgABGjx7N008/XeS2Xbp0Yfr06Wg0GoKDgxk9ejQ1atTQ2cbBwYGmTZsyaNAgpaEIIYQQJVpiYqK2sOerXbs29+7dM6pdxcX9+vXrxd7Wx8dHOxGLSqVi8uTJVK9eXekuhRBCiFKpatWq3LlzB29vb+2yO3fu6NxRZgijO9QV14IFCyy1KyGEEKJEmDNnDvb29jrL7O3tDZoy/VEWK+65ubl88cUXfPPNN9y+fZv09HSd9SqVimvXrlkqHCGEEMLqGjRoAOTN+R4fH4+HhwdVqlQxupO5xYr7rFmzWLFiBT4+PvTq1QsHBwdL7VoIIYSwSffv32fRokVcuHABZ2dnUlJSaNmyJe+++26hU6gXh8WK+7Zt2wgKCjJ6jlohhBCitPjoo4/w9vZm8eLFODk5kZqaytq1a1m9ejVBQUEGt6tohLr09HTefPNNzpw5o3hH6enpdOnSRfHzhBBCiNLq/PnzvPnmmzg5OQHg5OTEW2+9xfnz541qV1FxL1euHBs2bODhw4eKdzR27Fj27dun+HlCCCFEaVWhQgXi4uJ0lsXFxWmLvaEUn5bv0qULJ0+e1N7iVlydOnVi3rx5xMTE4OfnR6VKlQpsM2zYMKXhmJWDgwOOjo4Flt+3QixPUrFiRZO3mT+ioJOTU6HDClubtWN0cnIqMDAT2F6OmCM/wPqv/5PYQnxlOUds4fV/EkvEeP9+4f/bAwcOZPbs2YwYMYKqVasSHR3N119/zYABA4zap+LiHhwczNixY1Gr1QwYMAAvL68Cw8rq6wQwfvx4AP7991927txZYL1KpTJqkHxzyMzMJDMz09phFEtycrLJ21Sr1Tg4OJCammpz/zf5LBGjvi94+VJTU82yT1MzR36A7eeIpeKTHNHP1vMDrB/juHHjcHNzIywsTNtbfvTo0QwcONCodg365Q4wc+ZMZs2apXcbfS/QjRs3lO5KCCGEKPUGDhxodDF/nOLivmHDBoNmqnl8eD0hhBBCwJkzZzh27Bj37t2jcuXK+Pr60q5dO6PaVFzcAwICjNohwMOHDwsMYgP6T+cLIYQQpdWuXbv46quv6NevHw0aNCA2NpbFixczduxYRowYYXC7Bt/nnpCQwF9//cWtW7fo378/bm5upKen4+DgoLfziEajYfHixXz++edERUXpbdNWr8kIIYQQ5vD111/z4YcfakeqA+jTpw9z5swxqrgruhUO8oaRnTt3LjVr1sTHx4fx48drr6cPGzaMRYsW6X3eqlWrWLlyJa+//joajYZ33nmH+fPn06hRI+rUqcP69esNPgghhBCiJMrJyaFWrVo6y2rXrm30j13FxX3+/PmsWbOGFStWcOXKFZ1bBwYPHlzovexffvklQUFBzJw5E4ChQ4eyYMEC/v77b5o2bcrVq1cNPAQhhBCiZBo9ejSffPIJKSkpAKSkpLBmzRpGjRplVLuKT8tv2rSJ9957j1deeaXAN4v69esXOvnLzZs3eeaZZ1Cr1djb25OYmAiAnZ0dr732GpMmTeK9994z4BCEEEKIkmnnzp0kJSWxf/9+KlSowMOHD7Gzs8PFxUXntvHdu3craldxcb937x5NmzbVuy4nJ4esrCy96ypXrqz9ZlKrVi3Onj2Lr68vAPHx8QaNeieEEEKUZOaab0VxcW/UqBFHjx6ld+/eBdZFRETQokULvc/r2rUrZ86cYcCAAYwZM4aFCxcSHR2Nvb0969ev19ueEEIIUZq1atXKLO0qLu7Tpk1j8uTJ2Nvb88ILLwBw+/ZtfvvtN0JCQti0aZPe5y1cuJA7d+4AMHfuXBITE9m+fTtpaWn4+fnx8ccfG34UQgghRAmk0WjYs2cP+/btIyYmBi8vLwYPHmz0cOwG3ed+//59Fi5cqL1GPnToUJycnFi8eDH+/v56n9e4cWMaN24M5A3VuHr1alavXm1E6EIIIUTJ9u233xIREcG0adN45513eO2119iwYQPZ2dmF1tNg3ZbwAAAgAElEQVTiUNxbHiAwMJC7d+9y8OBBQkNDOXjwILdv3yYwMLDQ5/j6+nLp0iW9665cuaK9/i6EEEKUFd999x1z5syhVatW2NnZ0aFDB4KDg9m/f79R7Ro8iI2zszP9+vUr9vYRERE8ePBA77oHDx7w888/GxqKEEIIUSLFx8dTvXp1nWWVK1cmKSnJqHYNKu7x8fGsWrWKU6dOERUVRbVq1ejUqRNvvfUWnp6ehT6vsDHpT5w4QZUqVQwJRQghhCixnJ2dSU5OpmLFimg0GnJycti8eTPNmjUzql3Fp+VPnTpFw4YNWbNmDa6urvj4+ODq6srHH39MgwYNOHXqlHbbpUuX4uLigouLCyqVil69emkf5/85Ojoybdo0hg8fbtSBPMn+/fsJDAxk2LBhfPjhh2bdlxBCCFEc7dq1448//gAgOzub/v37c+7cuSIvcxeH4l/ur7/+Os2bN+fgwYO4uLholyclJdG/f3+mTJnCmTNngLzpYadPn45GoyE4OJjRo0dTo0YNnfYcHBxo2rQpgwYNMupAnsTd3R1/f3/OnTtntrmthRBCCCVmzJih/feKFSvw9PQs8gx4cSku7n///Te7du3SKewArq6uzJ49m5EjR2qX+fj44OPjA+Sdkp80aRLe3t5GhmyY/Hnor1+/LsVdCCGEzXjw4AEnT57UTvnaqVOnAjVWKcWn5Rs0aKAdOvZxSUlJ1KtXT++6BQsWWK2wCyGEELbo7NmzjBkzhj179nDx4kX27NnDmDFj+O9//2tUu4p/uX/44Ye8/vrr2lnh8kVERLBw4ULWrFmj93nFudUtPDxcaTgmFR8fT3x8vPaxnZ2d3tMj+gfYtS61Wm22Ns3RtqlYO8bC9mtrOWKu18far/+T2EJ8ZTlHbOH1fxJrxxgSEkJgYKBOjfzhhx8ICQlh48aNBreruLi//fbbJCUl4evri6urK56ensTFxZGUlISbmxuzZs1i1qxZQN6p+PPnzwNoO9U9KiEhgbNnz1KpUiXatWtn8EGYyu7du3Wmng0ICGDKlCkFttM/G711ubm5ma1tY08PWYK1Yizsdbe1HDFnfoDt54g145Mcsf38APPGGBcXV+i6+Ph4nR/KkPdj+KOPPjJqn4qLe9u2bQu9pa0o3377rd7l8fHxDB482Ojp7Uxh+PDhOi+ynZ0dCQkJVoyo+MwRp1qtxsXFhQcPHhg9t7C5WCLGoj70ynJ+gO3niKXikxzRz9bzA6wfY7du3fjxxx/p27evdtnRo0fp2rWrUe0aNOWrKXl4eDBz5kxmzpxp1FB7T5KTk0NOTg65ubnk5uaSmZmJnZ0dTz31fy+Bh4cHHh4e2sfx8fE2m5CPM2ec+a+dLbNWjLb+uuQzd5y2niPWjM+WX5dHyWeIdWJMS0vjww8/5JtvvsHLy4uYmBiuX79Oly5dWLRokXY7pbPHGTxCnSnl5OQQHR1t1n3s3LmTHTt2aB8fP34cX19fpk6datb9CiGEEIWpV6+eTkf0Bg0aGP2rHSxY3M+ePVtgWWZmJhcvXiQoKIgOHTqYdf9jxoxhzJgxZt2HEEIIocSECRPM0q7Finu7du0KXKvXaDQAdOzYUacjmxBCCCEMZ7HifuzYsQLLypUrR40aNeT+dyGEEMKELFbcH+/qL4QQQgjzMElxv3nzJlevXqVNmza4u7sXue2DBw+4ffs26enpBda1adPGFOEIIYQQJVpWVhb29vYGP19xcZ8+fTo5OTnaG+z37t3LqFGjyMrKws3NjbCwMNq2bVvgeXfu3OGll17i6NGjBdZpNBpUKpXN3yohhBBCmNOFCxf44YcfiIiI4Pvvvze4HcXFfe/evQQHB2sfz507lwEDBrBo0SLefvtt5s2bx6FDhwo8b8KECVy5coWQkBAaNWqEg4ODwUELIYQQpcW///7L0aNHCQ8PJyMjA19fX6OnJldc3KOioqhVqxYA165d4/Lly4SGhtKiRQveeOONQrv1nzp1itDQUIYMGWJUwEIIIURp8fLLL3Pnzh26devG9OnTadOmjUGjwD5O8axwrq6uxMbGAnlD5Lm7u2tPwzs6OpKWlqb3eQ0aNCAry9amShBCCCGs599//6Vu3bq0atWKJk2amKSwgwG/3Hv06MH8+fOJiYlh+fLlDB06VLvu8uXL2l/1j1u+fDnTp0+nZcuWNGrUyPCIhRBCiFLim2++4dixYxw6dIiQkBA6depE79696dSpk2U71K1atYrx48cze/Zs2rRpw5IlS7Trtm7dSvfu3fU+r3fv3vTp04dmzZpRvXp1KlWqpLP+0RnkhBBCiLKgYsWKDB48mMGDBxMdHc3Ro0f54osvWL58Od99953B7Sou7t7e3oXOu37kyBHKlSund92sWbNYuXIlbdu2lQ51QgghxGOqVq3K+PHjGT9+PJcvXzaqLZMOYlPUfLjr1q0jODiYefPmmXKXQgghRImVlpZGWFgYFSpUoHfv3tjZ5XWFa9y4sVHtKi7uubm5fPHFF3zzzTeFDkZz/fr1AsscHBzo2LGjYVEKIYQQpdCSJUuIiooiKyuLGzdu8PLLL3P48GHOnDmjeJrXRyku7rNmzWLFihX4+PjQq1evYp9enzx5MqGhofj5+SkOUgghhCiNzp49y65du0hOTmb69Om8/PLL+Pj48MUXXxjVruLivm3bNoKCghR/o3BxcSEiIoIuXbrQp08fvR3qpk2bpjQcIYQQosRydXVFrVZTtWpVkpKSALC3tycjI8OodhUX9/T0dLp06aJ4R7Nnzwbg1q1bnDx5ssB6Ke5CCCHKmokTJ7Ju3TpeeuklVCoVKSkphIaGUq9ePaPaVVzcx44dy759++jdu7ei5+Xm5irdlRBCCFGqvf/++wB8++23qFQqBg8eTJ06dYy63g4GFPdOnToxb948YmJi8PPzK3B6HWDYsGFGBWUrHBwccHR0LLD8vhVieZKKFSuavM38kZKcnJzQaDQmb98UrB2jk5OTtnfro2wtR8yRH2D91/9JbCG+spwjtvD6P4klYrx/v/D/7U2bNunE4urqapL/C8XFffz48UDekHk7d+4ssL40ze6WmZlJZmamtcMoluTkZJO3qVarcXBwIDU11Wb/Ty0Ro74vePlSU1PNsk9TM0d+gO3niKXikxzRz9bzA6wfY82aNc3SruLifuPGDXPEIYQQQpQ5y5YtK3TdrFmzDG5XcXGvXbu2wTsTQgghxP9xd3fXeRwdHc3Jkyfp06ePUe0aNEKdRqPh4MGD/Prrr9y/fx93d3e6d+9O//79TTajjRBCCFHaTZ48ucCy8+fPs3v3bqPaVVzcExISGDBgAKdOnaJSpUp4eXkRExPDsmXL6NSpEwcPHtTbyU4IIYQQT9aqVSvmzp1rVBuKi/uMGTO4du0aR44c0Rlt7ujRo4wbN44ZM2ZoR9bZs2ePorZLSy97IYQQwlCZmZlMnz6dnJwc1Gq1QW0oLu7ff/89H3zwQYFhZP38/Fi6dCmzZs3SFvcXXnih2O2Wpl72QgghRHFs3ry50HX5hX3btm2MHTtWUbuKi3tqaipeXl5611WtWlXntg/pWS+EEEIULjIy8onb3L59W3G7iot769atWbNmDf369dM5XZCbm8vHH39MmzZttMukZ70QQghRuOKMRGfILXGKi/vSpUvp27cvDRo0YMiQIXh5eREbG8u3335LdHQ0YWFh2m2LGpVHn8dvCRBCCCFKs/z53MuXL0+fPn30jmZoCMXFvUePHhw/fpwlS5bw1VdfkZCQgLu7O926deOdd97R+eXu4eGh6NY4ueYuhBCiLHl0PvebN29abz53gLZt2xarJ/yGDRvkvnchhBCiEDYzn7sSAQEB5mxeCCGEKNGsOp/74MGDWbFiBQ0bNmTw4MFFbqtSqfjuu++MCkoIIYQoC6w6n3tycrL2eviDBw8MPtX+888/s27dOq5cuUJ6enqB9RcuXDCoXSGEEKIksup87seOHdP+OyIiwqAdHTlyhIEDB9KnTx9+//13+vfvT1paGsePH6dGjRr4+PgobjMlJYVPPvmEs2fPUr58eZ5//nmGDBmid9vBgwfj6Oio/WLSrFkzFi5caNCxCCGEEKZgM/O5BwcHM2nSJKpXr15gXVRUFOvXr2f+/PkF1i1YsICpU6eybNky7O3tWbRoEW3atOHff/+lX79++Pr6Kg7+888/Jysri40bNxIbG8u7775LjRo1aNu2rd7tV61aRY0aNRTvRwghhDAHm5nPPSgoiGeffVZvcb979y5BQUF6i/vFixdZsmQJdnZ2qFQq7Uh2tWvXZuHChSxcuJBx48YVO4709HSOHz/OqlWrqFChAnXq1KFv374cPXq00OIuhBBC2BJzzeeu+G55jUZT6DX3qKioQmeEK1euHLm5uahUKqpVq8a1a9e06ypWrMitW7cUxXHnzh00Go3OKHh169Ytcii/efPmMX78eIKDg4s15J8QQghhTu7u7jp/AMePH8fR0dGodov1y3379u1s374dyLsmMH369AJFPD09nd9//52uXbvqbaNVq1ZcvnwZPz8/evfuzZIlS/Dw8MDe3p558+bx9NNPKwo8PT2dChUq6CxzcnIiLS1N7/bvvfcejRs3Jisriz179jB//nzWrl2r00Z8fDzx8fHax3Z2dnh6ehZoK0tRpJZh6MxBxWnTHG2birVjLGy/tpYj5np9rP36P4ktxFeWc8QWXv8nsXaM+uZz//vvv9m5c6dR7RaruGdmZpKcnAzk/XJPTU0t8EI4ODjw4osvMnPmTL1tTJ06VTuRzHvvvcegQYO0t9XVqFGDvXv3Kgq8XLlyBQr5w4cPKV++vN7tW7RoAeTdPzhu3DiOHTvGxYsXdU7h7969m/Xr12sfBwQEMGXKlAJtRSmK1DLc3NzM1raLi4vZ2jYVa8VY2OtuazlizvwA288Ra8YnOWL7+QHmjTEuLk7R9s2aNeOPP/4wap/FKu4TJkxgwoQJAPTq1YtPP/2UJk2aKNrRgAEDtP/29vbmjz/+4OrVq6SlpdGkSRMcHBwUteft7Q3kzahTq1YtIG8Wuvx/P4m+SwvDhw/X6bVvZ2dHQkKCorisxRxxqtVqXFxcePDggc0ODWyJGIv60CvL+QG2nyOWik9yRD9bzw+wfoyPXyLOyMggLCyMatWqGdWu4g51j94WZwyVSkXDhg0Nfn65cuXo2rUrW7duZdq0acTFxREWFsZbb71VYNvIyEiysrKoU6cO2dnZ7N69m8zMTBo3bqyznYeHBx4eHtrH8fHxNpuQjzNnnDk5OTb/OlgrRlt/XfKZO05bzxFrxmfLr8uj5DPEOjH+5z//0enLVq5cORo0aMCcOXOMateg4Wdzc3MJDw/XOxiNSqVi2rRpAHz66adMnDhRUceAP//8k7i4uGLdGvfKK6+wZs0aAgICKF++PMOHD9eeZvf392fBggU0b96cxMREPv30U+Lj43FwcKBBgwYEBQXh7Oys4KiFEEII0/rxxx/N0q7i4h4dHY2Pjw//+9//UKlUaDQaQPc0d35x37RpE0FBQYwePZoRI0bQvn177O3tC7R59+5dDh06xPbt2zl16pTOTf1FcXZ2Zvbs2XrXff3119p/t2zZkk8//bS4hyiEEEJY1aJFiyw7K1xgYCAeHh6Eh4dTs2ZNTp06hZeXF6GhoWzZsoUDBw5otz116hR79+5l9erVhISEYG9vT6NGjfD09MTR0ZHExERu3LhBbGws7u7uTJgwgdDQUKpWrWrwAQkhhBAlxfHjx7XTp+f/WAaIjY3ln3/+AdDeraaE4uL+888/ExISor3Yr9FoqFWrFnPnzkWj0TBlyhQOHTqk3f7555/n+eef5+bNm/zwww/8/vvvREVFkZ6eTu3atenbty9du3alZ8+een/VCyGEEKXVxx9/zOjRo3UGhlOpVLz77rsEBgYa3K7i4p6UlISnpyd2dna4uLgQGxurXde5c2ftIPiPq1OnDpMmTWLSpEkGByuEEEKUJg8fPtQ7J4qdnR3t27c3uF3FI9TVrVuXqKi8OzSbN2/O1q1btev27t2rHWFHCCGEEEV7/vnn9S4fPny4Ue0q/uU+cOBAwsLC8Pf3Z968eQwZMoQqVapgb29PdHR0kePkCiGEEOL/5I/emn9r9rlz58jKymLixIlGtau4uC9dulT77/79+3PixAn27t1LWloafn5+9O/f36iAhBBCiLJi7dq12mvr33//PZs2bcLe3p5evXrx6quvGtyu4uIeGRlJtWrVtJ3f2rVrR7t27QDIysrSGTFOCCGEEIWLjo6mUaNGABw6dIh33nmHevXq8dJLLxlV3A265v7f//5X77oLFy5Qt25dg4MRQgghypKnnnqK3NxcUlJSuHPnDs888wxubm5kZmYa167SJzx6H97jMjIyjJ6mTgghhCgrnn76aVasWEFGRgbt27dHrVYTHR2tMxS6IYpV3C9duqS9mR4gIiKC27dv62yTnp7O9u3bqVevnlEBCSGEEGVFYGAg69atw9HRkZdfflm7PH+kV0MVq7jv3LmToKAgIO/m+sKGfK1UqVKxh44VQgghyjo3NzdmzZqls6xq1apGj9RarOI+depUAgIC0Gg01KtXjz179tC6dWudbRwcHKhatareqVSFEEIIYTnFKu6urq64uroCeXOmV6tWTfH860IIIYSwDMUd6lQqFdHR0UVuI7fCCSGEENajuLjXqVPniaferTHhvRBCCCHyKC7ue/fuLbAsISGBI0eOcPLkyUInjhFCCCGEZSgu7vpmrwEICAggMDCQn376iZEjRxodmC1wcHDQe9/+fSvE8iQVK1Y0eZv5Z2icnJyKHN/Amqwdo5OTE3Z2BceCsrUcMUd+gPVf/yexhfjKco7Ywuv/JJaI8f59y/9vKy7uRRkwYAD+/v6sXbvWlM1aTWZmptGjBFlKcnKyydtUq9U4ODiQmppqs5daLBFjUQMzpaammmWfpmaO/ADbzxFLxSc5op+t5weUjBgNoXj42aKcOHGCcuXKmbJJIYQQQiik+Jf7m2++WWBZZmYmFy9e5Ndff2XGjBkmCUwIYVnXrl3jjTfe4N69e7i4uPDxxx/TpEmTAtuFhoYSEhKCRqOhe/fufPnllwDk5uYSFBREeHg42dnZdOjQgQ8//FB722xISAg7d+7E3t6ecuXK8d5779GmTRuLHqMwnDnzIzw8nODgYG0b8fHxVKlShfDwcIsdX2mj+Jf7vn37Cvz99NNPODg4sHbtWt577z1zxCmMdO3aNQYMGEDHjh3x8/Pj0qVLercLDQ2lQ4cOtG/fnrfeeousrCwg7425YMECunfvTufOnXnrrbe0lywiIyPx8vKiZ8+e2r8bN26YPb5p06YVK75HTZkyBU9PT5KSkhTFVxbMmDGD8ePHc+rUKd544w3eeOONAtv8+++/vP/+++zbt4/Tp08TFxfHunXrANi2bRsXLlzgxx9/5MSJE9jZ2WnX/fnnn2zcuJEjR44QERHBSy+9VOhIl4UxZw4D3L59m7Fjx9KpUye6du3K+vXrFcVX2pkzP3x9fYmIiND+tWzZkhdeeEFxjLb+OWdJiov7jRs3CvxdvHiRo0eP8sorr6BWq80RpzCSOd+YAM7OzjpvTqWzAxoa3+bNmwHYunVrkfEB7N+/XztVsdAVFxfHuXPnGDFiBACDBg3izp07XL9+XWe7ffv28eyzz+Ll5YVKpeI///kP27dvB+Cvv/6iR48eODg4oFKp6N27N7t27QLyOi1lZWXx8OFDAJKSkqhevbqiGM2ZwxqNhgkTJuDv78/Jkyc5fvx4oZ2HyyJz58ejoqOj+eWXX7T7UsLWP+csyaTX3IVtsuQb05LxTZgwgd27dwPw999/FxlfbGwsH330EYsWLTJJzKXN3bt38fLy4qmn8q7UqVQqatSowZ07d3S2u337NjVq1NA+rlmzJpGRkQC0atWKI0eOkJycTFZWFt999512XYsWLXj11Vdp164dLVu25PPPP2fp0qXFjs/cOfzzzz/j6OioU9CrVKlS7PhKO3Pnx6O2b99O79698fT0VBSjrX/OWZpBxf3WrVt8/PHHzJw5kzfffFPn76233jJ1jMJIlnhjPnz4ED8/P3x9fVm+fLmiXqeGxlerVi3t7IRPii8wMJAFCxbg7Oxc7LiEMqNHj8bX15fBgwczZMgQ6tevr/0//ffffzlw4ACnT5/mwoULvPLKK0yaNKnYbZs7hy9fvkzlypWZPHkyvXr1YsKECdy8edOYl0M8pqj8yKfRaPjqq68YO3as4vZt/XPO0hR3qPv6668ZP348ubm5VKlSpcAY8yqVitWrV5ssQGEbRo8eze3btxk8eDDly5enR48eREREAODl5cWFCxfw9PQkISGByZMns3btWr2nxMxlzJgxREZG6o1v69ateHt70717d4vFU9JUr16dmJgYsrOzeeqpp9BoNNy+fRtvb2+d7WrUqKFT9G7duqUdblqlUjFz5kxmzpwJ5A141bhxYyDvkkjTpk21M12NHj2aOXPmkJmZabF5KorK4ZycHH755RcOHz5MkyZN2LRpE5MmTeKHH36wSGy2ztz5ke/EiRNkZGTg6+tr3gMqhK1/zimh+Jf73LlzGTp0KPHx8dy5c6fA9ffHT4EI63v0jQkU+cbM/yUM+t+Yx44d4+DBgzRu3Fj7xnR0dNSeQnNzc2PMmDGcPHnS7PFFRkZqv4EXFd/x48c5fPgwbdq00fbO9vHx4cKFC8WOsbTz9PSkZcuW2lOQ+/bto3r16tSrV09nu+eee47Dhw8TExODRqNh48aNjBo1CoD09HQSExMBuHfvHqtXr9Z+8NWuXZvTp0+TkpICQFhYGPXr1y92YTd3Dnt7e/P0009re3+PGDGCCxcuaDtalXXmzo9827ZtY9SoUQb13bL1zzlLU1zc4+LiePnll7WzxAnbZ+43ZlxcnPZDMCMjg/379/P000+bPb7NmzczbNiwJ8b32Wefcf78ec6ePcvZs2cB+Omnn2jZsmWxYywLVqxYwZYtW+jYsSMhISGEhIQAeVM+Hz58GMibW2LWrFk899xzdOjQgcqVK/PKK68A8ODBAwYMGEC3bt0YNGgQAQEB9OvXD4CBAwfSr18//Pz86NmzJ+vXr+fzzz8vdmzmzuHevXsTFRVFVFQUAD/88AONGjWSDpiPMGd+5K8/cOAAY8aMMSg+W/+cszSVRuF4eyNHjqRly5a888475orJZsTHx+tdnrVfWUcPS7B/Lq7I9VevXuWNN97g/v37VKxYkZCQEJo1a8bUqVN59tlnefbZZ4G8U9j5b9quXbuyceNGUlJSiIqKYujQodjZ2ZGbm8vLL79MQEAAkHfKddmyZajVarKzs+nWrRtBQUFFjtplivi6dOnCqlWrqFKlCpcvX2bQoEF643ucp6cnV69eLfYXVA8Pj0LXlZQceVJ+GEqtVuPm5kZCQoLZrz+aM4cBjh07RlBQEJA3FOuyZcto1qxZsWKTHNHPkvkBtvs5Z8rhZxs1alSs7RQX94SEBEaOHEn79u3p3bs3lSpVKrBNaRmYoqS8KaF0vDENYYkY5YO7cLaeI5aKT3JEP1vPD7BMjNYo7oo71CUnJ/Pw4UOWLl1aYAY4jUaDSqWy2f/EsuT1U7kmaCUXiDVBO/BJR90rQJ77bG/2wLhBygZVKekkR5QrSzlia/kBtp8jtpQfiov7iy++SGRkJB9//DGNGjWyWE9XIYQQQhSP4uJ++vRpvvrqK4YOHWqOeIQQQghhJMXFvWHDhtpbDUqSlJQUPvnkE86ePUv58uV5/vnnZXhJIYQQpZLiW+FWrlzJkiVLCh2Q31Z9/vnnZGVlsXHjRhYuXMg333zDH3/8Ye2whBBCCJNT/Mt96tSpREdH06JFC6pXr16gt7xKpeL8+fMmC9AU0tPTOX78OKtWraJChQrUqVOHvn37cvToUdq2bWvt8IQQQgiTUlzc27Zti0qlMkcsZnPnzh00Gg21a9fWLqtbty6//fabFaMSQgghzENxcd+0aZMZwjCv9PR0KlSooLPMycmJtLQ0nWXx8fE696Ta2dnpnZnIFgekLDhcoyluYzGdkjAVsCExFvYcW8sR/XFKjihVtnLEtvIDbD9HbCk+xcW9JCpXrlyBQv7w4UPKly+vs2z37t2sX79e+zggIIApU6YUbDBA0bg/VrFzoLUjKJrmP8utHYJJuLm56V8hOWI0yRHrsvX8gJKTI3Fx5hlEqihlorjnTxwQGRmpnSDgxo0b2n/nGz58OD4+PtrHdnZ2JCQkmC0utVqNi4sLDx48sMmBf2w9PrBMjIV+OEOZzg+w/RgtFZ/kiH62Hh+UjBgNUSaKe7ly5ejatStbt25l2rRpxMXFERYWVmDueQ8PD51hJOPj4y3yn52Tk2PTSWXr8YH1YpT8yGPrMVozPskR248PSkaMSpSJ4g7wyiuvsGbNGgICAihfvjzDhw+XnvJCCCFKpTJT3J2dnZk923bG/RVCCCHMRfGscMJ04uPj2b17N8OHDy9yVilrsfX4oGTEaKiScGy2HqOtx2csWz8+W48PSkaMhlA8Qp0wnfj4eNavX1/olJDWZuvxQcmI0VAl4dhsPUZbj89Ytn58th4flIwYDSHFXQghhChlpLgLIYQQpYx64cKFC60dRFlWvnx52rVrV2AEPVth6/FByYjRUCXh2Gw9RluPz1i2fny2Hh+UjBiVkg51QgghRCkjp+WFEEKIUkaKuxBCCFHKSHEXQgghSpkyM0KdKH3i4+NJSEjAzc2tVA0+IUxHckQUpTTnhxR3K4uJiSEqKor69etTsWJFq8YSGxvLw4cPqVOnDgBZWVns3buXW7du8cwzz9C7d2+rxpfv8OHDfP3119y/f1+7zN3dHX9/f5599lkrRmYekiPKSY5YT0nIkbKQH3IrnAV9+eWX/PHHH9oJa3777TfmzuV2ksAAABqISURBVJ1LeHg4YWFhtGrVCnd3d6vFt2zZMhITE2ndujUAGzZs4Ntvv0WtVnP06FEqVqxIw4YNrRYfwK5du9iwYQMdO3Zk7NixDBo0iPbt25ORkcHu3btRq9U0b97cqjEaQ3LEeJIjkiNFKe35kU+uuVvQyZMnadCggfbx1q1badeuHSEhITRs2JDQ0FArRpc3x31+Uufk5BAeHs6ECRNYuXIlo0aN4tChQ1aND+DAgQM8//zzTJs2jQ4dOtCoUSM6dOjAtGnTGDJkCAcOHLB2iEaRHDGe5IjkSFFKe37kk+JuQQkJCXh6egIQFRXFnTt38Pf3p3bt2jz33HNcvXrVqvGlpaVpB3G4fPkyaWlpdO/eHYBmzZoRHR1tzfAAePjwIa1atdK77plnniEtLc3CEZmW5IjxJEckR4pS2vMjnxR3C6pQoQJJSUkAnDt3DmdnZ+03cHt7ezIzM60ZHpUrV+by5ctA3qm+mjVrak/vpaSk4OjoaM3wAGjdujXnz5/Xu+7cuXO0bNnSwhGZluSI8SRHJEeKUtrzI590qLOg5s2b89VXX5GYmMjevXvp1KmTdt2dO3e038atxc/Pj23btnH8+HGuX7/OpEmTtOsuX75MjRo1rBhdnr59+/LJJ5+QlJREx44dqVSpEomJiZw8eZILFy7w+uuvc+3aNe329evXt2K0ykmOGE9yRHKkKKU9P/LJ8LMWdO/ePVauXMnVq1epV68eM2fOxM3NDYC3336bOnXq8Prrr1s1xvDwcP73v/9Rv359evfujUqlAmDt2rU0adIEX19fq8Y3ZMgQnccqlYpHUzg/Xo1Gg0ql4ttvv7VofMaSHDGe5IjkSFFKe37kk+JuIx4+fIi9vT329vbWDsWm/fXXX4q2b9GihZkisTzJkeKRHJEcKUpZyQ8p7kIrLi7uidtY+5SfsC7JEfEkkiO2QYq7Bb3zzjtP3GbJkiUWiES/IUOGaE9JFcZWTlFFRkbyzz//kJycTMWKFWnWrBm1atWydlhGkxwxHckR6ygpOVJa8yOfdKizoAoVKhRI+pSUFK5du4aTk5POvavWMGfOnALLUlNTOXv2LJcvX2bChAlWiEpXVlYWK1eu5LfffkOj0WBvb09WVhYqlYouXbowbdq0En1KUnLEeJIjkiNFKe35oaURVpeUlKR5++23Nb/88ou1QynUF198oVm7dq21w9B88cUXmhdeeEFz+PBhTWpqqkaj0WhSU1M1hw8f1owYMULz5ZdfWjlC85AcURaH5IhtsoUcKSv5Ife52wAXFxeGDRtm9ZGlitK2bVt++eUXa4fBL7/8wosvvki/fv20A2VUqFCBfv36MW7cOH7++WcrR2gekiPFJzkiOVKUspIfUtxtRG5uLgkJCdYOo1CXLl3CwcHB2mGQkpJS6H2yNWrUICUlxcIRWY7kSPFIjkiOFKWs5Idcc7egRwdGyJeVlcXt27fZsWMHjRo1skJU/2fdunUFlmVnZ3Pr1i0uXrzI0KFDrRCVLm9vb44dO6adlOJREREReHt7WyEq05EcMZ7kiORIUUp7fuST4m5BgYGBBTrCaP7/mxUaNWpk9YEnTp8+XWCZg4MDlStX5tVXX8XPz88KUekaOXIkH3zwAbGxsXTu3JlKlSqRlJTEiRMnuHTpErNmzbJ2iEaRHDGe5IjkSFFKe37kk1vhLEjf4An29vZ4eHhQuXJlK0RUMp06dYodO3Zw48YN7ShSdevWZfTo0XTo0MHa4RlFcsQ0JEdEUUpzfuST4i5KrPT0dFJTU3FycqJcuXLWDkfYIMkRUZTSnB9S3C1Mo9Hw+++/888//5CSkoKzszPNmzenbdu2Txz4wRKuXbvGrl27uHjxos7gDiNGjKBevXrWDo/Vq1czcuRIqlatWmBdbGws27dv56233rJCZKYjOWIcyRHJkaKUhfwAKe4WlZKSQlBQEFeuXMHJyUk7G1FqaiqNGzdm/vz5ODs7Wy2+v//+m/nz5+Pm5qa9FpWYmMhvv/1GYmIiwcHBNGvWzGrxQd7oVx9++KHeTkNXr15lxowZNjH6laEkR4wnOSI5UpTSnh/5pEOdBW3YsIHo6GgWLlyo01Pzv//9LytXrmTjxo288cYbVotv8+bNtGjRgvnz56NWq7XLAwICCA4OZvPmzSxbtsxq8eUr7JfJ3bt3qVixooWjMS3JEdOQHJEcKUppzo98Utwt6PTp0wQEBBS4BaN169a8+OKLbN682apvyuvXrzN79mydNySAWq1m0KBBvP/++1aJ6+DBgxw6dAjIe1MuX768wL2yWVlZxMbG0rVrV2uEaDKSI4aRHJEcKUpZyo98UtwtKD09nUqVKuld5+bmRnp6uoUj0lWuXDmSkpL0rktMTLRahxN3d3fteNmRkZF4e3vj6uqqs81TTz1FjRo1rH6bjbEkRwwjOZJHckS/spQf+aS4W1C9evU4cOAArVu31vlWm5uby/79+6lfv74Vo4P27duzadMmKleuzDPPPKNdfu7cObZs2WK1W0Q6depEp06dtI8f7wyTkZHBvXv3qFatmk10JjKG5IhhJEckR4pSlvIjn3Sos6C//vqLBQsW4ObmRseOHbWDJ5w8eZLExESCgoJo3ry51eJLSUlh4cKFXL16lfLly2s7wqSlpdGgQQMWLlxo1Y46AHv27CEjI4PRo0cDeZ13Fi9e/P+1d/cxUVyNGsCfAcSPXZAPRVw/SsRSpSJVUaEGX8WCtppqoqmRqo2NtR+JMQbjamwarbaSqIkSE21sm6JEowXRJrWpIChRa6XYriAWKhaR1bTuQsEFAVn3/uHt3ssLeCaxzpnuPL//3NnEJ+SZnJ05Z87gwYMHiIiIwJYtWzB06FCpGZ8GO/L02BF25El8vR9/4+CusRs3buDYsWO4fv269xGW2NhYvPHGG9J/cQOPf/2XlpaisrISLS0t3nwJCQnw85P/KoIPPvgACxYsQFpaGoDHu3X16dMHixYtwtGjRxEREYH169dLTvl02JGnw46wI09ihH4A4Ctf6d9l0aJFnvLyco/H4/E4HA7P66+/7qmoqPB4PB7PDz/84Fm+fLnMeKQD7Ag9iVH6wTl36qa1tRUOhwMPHz7sdkz2VUFgYCBaW1sBADabDf369cOYMWMAACaTCS0tLTLjGQY7QiJ67YhR+sHBXWMlJSW4cOECHA4HOjo6uhxTFAVZWVmSkgFOpxNZWVmw2Wzdjnn+d/9l2Zs7xMTEIDc3F4qiID8/H5MmTfIuKrp7965P7K3NjjwddoQdeRIj9APg4K6pgwcPIi8vD9HR0Rg2bBgCAvT159+9ezfsdjveeecdWCwW9OnTR3akblasWIGtW7di27ZtGDx4MJYuXeo9dv78ee8v8H8rduTpsSNy6b0jvt6Pv3FBnYaWL1+OuXPnYvHixbKj9Gjx4sVYu3Ztl0dG9Kq5uRnBwcFdPqutrUVoaGi351f/TdiRfw47Ise/pSO+2o+/6esnnwH0tJ+xXkRGRsLtdsuOocp/n5QAEBUVpX2QZ4Ad+WewI3L8Wzriy/0AAP/Nmzdvlh3CKFpaWvDrr7/q9hetxWJBTk4Oxo8f32Px6dljR0iEHSE1eFteQx6PBwcOHMCNGzcQHx8Pk8nU5biiKJg/f76kdI99+eWX+OabbxAWFtZjPpkLdYyAHSERdoTU4G15DV29ehVFRUV48OABqqqquh2XfVJ+9dVXOHnypG4X6hgBO0Ii7AipwSt3Db3//vsIDw/HqlWrYLFYdFf6JUuWYMGCBbpdqGME7AiJsCOkhvy9Ig3E4XBg4cKFGDlypO5OSODxW5H0vFDHCNgREmFHSA0O7hqKjY2F3W6XHaNXs2fPxtmzZ2XHMDR2hETYEVJDfz/7fNiyZcuwe/duBAQE4KWXXuq20AQAgoKCJCR7rH///qioqMD69et1u1DH17EjJMKOkBqcc9fQ/y90b+8Mlrkto+iEk71tpBGwIyTCjpAaHNw1dObMGeF3Zs2apUES0it2hETYEVKDgzt5/f1eaKLesCMkwo7oA3eo09COHTtgMpkQGRkpO0qP0tPTcfv2bV1n9HXsCImwI6QGB3cN5efnIy8vD2fOnEFLSwuGDBnS42IYWcxmM65evYq8vDwUFRWhtbVVdxl9HTtCIuwIqcHb8hqrq6tDQUEBzp07h+bmZsTFxSE1NRVJSUm6eTXirVu3UFhYiLNnz+L+/fuIj49HamoqEhMTdflcra9hR0iEHSERDu6SuN1ulJaWorCwEFeuXEH//v0xffp0pKamYtSoUbLjAXic8fLly8jPz0d1dTVMJhNmzJiBuXPnwmKxyI7n89gREmFHqDe8LS+Jn58fLBYL+vbtiz/++AN3795FXV0dTp06BZvNhrFjx0p9o9KjR49w5coVnDlzBhUVFRg4cCCSkpJQVlaGvLw8hISEYPTo0dLyGQE7QiLsCPWGV+4S1NfXe29XNTc3IyEhAbNnz8aECRNQXl6O7OxsKIqCXbt2aZ7tzp07KCgoQHFxMZqamjBx4kSkpaUhISEB/v7+8Hg8yM7ORlFREQ4ePKh5PqNgR0iEHaEn4cSHhk6fPo3CwkJUV1cjIiIC8+bNw6xZsxAaGur9Tnx8PN5++218+OGHmuezWq2oqqrCoEGDMGfOHKSmpiI8PLzLdxRFwbRp05Cfn695PiNgR0iEHSE1eOWuoYULFyIxMRFpaWmIj4/v9XsNDQ34/vvvsWTJEg3TAZmZmUhLS8OECRN63fkKADo7O9HQ0ICIiAgN0xkDO0Ii7AipwcFdQ83NzVLnv0j/2BESYUdIDQ7u1IXb7UZ1dTWcTic6Ojq6HU9JSZGQivSEHSERdkQ+zrlrqL29HUePHsXFixfhcDjQ2dnZ7TsyX6hQU1OD7du3w+FwoKfffIqi8KR8xtgREmFHSA0O7hrav38/SkpKMH36dIwYMUJ3Gzns27cPAwYMwLZt23SZzwjYERJhR0gN/tU1VFpaihUrVmDevHmyo/Sorq4OVqsV48aNkx3FsNgREmFHSA0/2QGMxM/PD8OGDZMdo1cWiwWtra2yYxgaO0Ii7AipwR3qNNTW1oby8nIkJSXJjtKj4cOHIycnB3FxcVyNKwk7QiLsCKnB1fIaOn78OE6dOoWwsDDEx8d3e0uSoiiYP3++pHTA6tWr0djYCJfLhbCwsB7zZWVlSUpnDOwIibAjpAbn3DWUnZ0NALh37x6qqqq6HZd9UkZHRz9x0wl69tgREmFHSA1euRMREfkYLqijHrW3t6OhoQHt7e2yo5BOsSMkwo7Iw9vyGmtra8OZM2dQWVkJl8sFs9mMF198ESkpKejXr5/seCgtLcWRI0dw8+ZN72ejRo1Ceno6EhISJCYzDnaERNgREuFteQ3du3cPmzZtwp9//omoqCiEhITgr7/+Qm1tLSIiIvDJJ59g8ODB0vJdunQJmZmZiImJQXJyMkJCQtDY2IgLFy6gqqoKGzZsQGJiorR8RsCOkAg7QmpwcNdQZmYmbt68iY8++gjDhw/3fl5fX4+tW7di1KhRsFqt0vKtWbMGI0eOREZGRrdju3btQl1dHfbs2SMhmXGwIyTCjpAanHPXkM1mw7Jly7qckMDj50LffPNN/PLLL5KSPWa323vd83nmzJmw2+0aJzIedoRE2BFSg4O7htxuNwIDA3s8FhgYiEePHmmcqCuz2dzriWe322E2mzVOZDzsCImwI6QGB3cNjR07FseOHUNLS0uXz1taWvD1119jzJgxkpI9lpycjEOHDuH06dNwuVzebKdPn0ZOTg6Sk5Ol5jMCdoRE2BFSg3PuGrp16xY2btwIt9uN8ePHIyQkBE1NTbDZbAgICMCnn36K5557Tlq+hw8fYufOnbh06RIURYG/vz/cbjc8Hg+SkpKQkZGBPn36SMtnBOwIibAjpAYHd405HA6cPHnS+whLUFAQxo4di/nz52PQoEGy4wEAamtruzxiExsbi6ioKNmxDIMdIRF2hEQ4uBMREfkYbmJDXbjdblRXV8PpdKKjo6Pb8d5WwZJxsCMkwo7Ix8FdQ+3t7Th69CguXrwIh8OBzs7Obt85ceKEhGSP1dTUYPv27XA4HOjpho6iKDwpnzF2hETYEVKDg7uG9u/fj5KSEkyfPh0jRoxAQIC+/vz79u3DgAEDsG3bNl3mMwJ2hETYEVKDf3UNlZaWYsWKFZg3b57sKD2qq6uD1WrFuHHjZEcxLHaERNgRUoPPuWvIz88Pw4YNkx2jVxaLBa2trbJjGBo7QiLsCKnhv3nz5s2yQxhFW1sbysvLkZSUJDtKj4YPH46cnBzExcUhODhYdhxDYkdIhB0hNfgonIaOHz+OU6dOISwsDPHx8TCZTF2OK4qC+fPnS0oHrF69Go2NjXC5XAgLC+sxX1ZWlqR0xsCOkAg7Qmpwzl1D2dnZAB6/srGqqqrbcdknZXR0NBRFkfb/EztCYuwIqcErdyIiIh/DBXUa+vslCnr13XffcSGMZOwIibAjpAYX1GkoPT0dt2/fhslkQmRkpOw43WzcuBEnTpxAfX09goKCEBERITuS4bAjJMKOkBoc3DVkNptx9epV5OXloaioCK2trRgyZEi3BSeyvPbaawgNDYXNZkNubi6Ki4vx4MEDREZGYsCAAbLjGQI7QiLsCKnBOXcJbt26hcLCQpw9exb3799HfHw8UlNTkZiYqJvdnH7//XcUFhaipKQELpcLEyZMwCuvvIIpU6boJqMvY0dIhB2hJ+HgLpHb7cbly5eRn5+P6upqmEwmzJgxA3PnzoXFYpEdDwDgdDqxa9cuXLt2DQAQHByMV199FQsXLkTfvn0lp/N97AiJsCPUEw7ukjx69AhlZWUoKCjATz/9hODgYEyZMgU///wznE4n3n33XcyePVtKNo/HgytXrqCgoAClpaUwmUxISUlBYmIiysrK8O233yIuLg4bN26Uks8o2BESYUeoNxzcNXbnzh0UFBSguLgYTU1NmDhxItLS0pCQkAB/f394PB5kZ2ejqKgIBw8e1DTb3bt3UVhYiOLiYjQ0NCA+Ph6zZ8/G1KlT4e/v7/3ejz/+iB07diA3N1fTfEbBjpAIO0IinPTQkNVqRVVVFQYNGoQ5c+YgNTUV4eHhXb6jKAqmTZuG/Px8zfO99957CA8Px6xZs5CamtrrKtfhw4fjhRde0DidMbAjJMKOkBq8ctdQZmYm0tLSMGHChCfu4NTZ2YmGhgbNHyEpLS3FpEmT4Of3f9sftLe3w+l0YujQodx1SgPsCImwI6QGB3fyys/PR1tbG5YsWQIAuHbtGrZt24YHDx4gIiICW7ZswdChQyWnJJnYERJhR/SBO9Rp6MaNG7DZbN5/u1wu7N27F1arFYcPH8ajR48kpgNOnz7d5fbeF198gZEjR2LTpk0IDg7GoUOHJKYzBnaERNgRUoODu4Y+//xzVFZWev994MABnD9/HqGhoThx4gSOHTsmMR3gcDi8j844nU7U1NRg+fLlmDx5MhYtWuR9jIWeHXaERNgRUoODu4Zu376NmJgYAI/noC5evIiVK1diw4YNeOutt3D27Fmp+QIDA717QttsNvTr1w9jxowBAJhMJrS0tMiMZwjsCImwI6QGV8trqL293bthw/Xr1/Hw4UNMnToVABAVFQWHwyEzHmJiYpCbmwtFUZCfn49JkyZ5H125e/dutxW59M9jR0iEHSE1eOWuocjISJSVlQEAzp07h9GjRyMoKAgA0NTUJH3f5RUrVqCxsdG7+GXp0qXeY+fPn/f++qZnhx0hEXaE1OBqeQ0VFBRg7969CAoKgsvlwtq1a/Gf//wHAPDZZ5/Bbrfj448/lpwSaG5uRnBwcJfPamtrERoaioEDB0pKZQzsCImwI6QGB3eNVVRU4LfffkN0dDTGjx/v/fzw4cN4/vnnMXnyZInpSA/YERJhR0iEgzsREZGP4YI6jbndblRXV8PpdKKjo6PLMUVRMHPmTEnJSC/YERJhR0iEg7uGampqsH37djgcDvR0w4QnJbEjJMKOkBq8La+hdevWoaOjA6tWrcKIESMQEND9t5XJZJKQjPSCHSERdoTU4JW7hurq6mC1WjFu3DjZUUin2BESYUdIDT7nriGLxeLduYmoJ+wIibAjpAYHdw2tXLkSubm5qK+vlx2FdIodIRF2hNTgnLuGVq9ejcbGRrhcLoSFhXWbF1MUBVlZWZLSkR6wIyTCjpAanHPXUHR0NBRFkR2DdIwdIRF2hNTglTsREZGP4Zy7JO3t7WhoaEB7e7vsKKRT7AiJsCPUG96W11hpaSmOHDmCmzdvej8bNWoU0tPTkZCQIDEZ6QU7QiLsCInwtryGLl26hMzMTMTExCA5ORkhISFobGzEhQsXUFVVhQ0bNiAxMVF2TJKIHSERdoTU4OCuoTVr1mDkyJHIyMjodmzXrl2oq6vDnj17JCQjvWBHSIQdITU4564hu92OlJSUHo/NnDkTdrtd40SkN+wIibAjpAYHdw2ZzeZeTzy73Q6z2axxItIbdoRE2BFSgwvqNJScnIxDhw4hMDAQL7/8MsxmM1paWnDhwgXk5OQgLS1NdkSSjB0hEXaE1OCcu4YePnyInTt34tKlS1AUBf7+/nC73fB4PEhKSkJGRgb69OkjOyZJxI6QCDtCanBwl6C2thaVlZVwuVwwm82IjY1FVFSU7FikI+wIibAj9CQc3DXmdrtRXV0Np9OJjo6Obsd7WyhDxsGOkAg7QiKcc9dQTU0Ntm/fDofDgZ5+UymKwpPS4NgREmFHSA1euWto3bp16OjowKpVqzBixAgEBHT/bfXfb3giY2FHSIQdITV45a6huro6WK1WjBs3TnYU0il2hETYEVKDz7lryGKxoLW1VXYM0jF2hETYEVKDg7uGVq5cidzcXNTX18uOQjrFjpAIO0JqcM5dQ6tXr0ZjYyNcLhfCwsK6zYspioKsrCxJ6UgP2BESYUdIDc65ayg6OhqKosiOQTrGjpAIO0Jq8MqdiIjIx3DOnYiIyMdwcCciIvIxHNyJiIh8DAd3IiIiH8PBnYiIyMdwcCciIvIxHNyJiIh8DAd3IiIiH/M/Lj40bAYBDlUAAAAASUVORK5CYII=\n",
@@ -735,8 +713,300 @@
     }
    ],
    "source": [
-    "p = variants.plotNumCodonMutsByType('all', samples=None)\n",
-    "_ = p.draw()"
+    "for mut_type in ['single', 'all']:\n",
+    "    p = variants.plotNumCodonMutsByType(mut_type, samples=None)\n",
+    "    _ = p.draw()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here are the numerical data in the plots above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>library</th>\n",
+       "      <th>sample</th>\n",
+       "      <th>mutation_type</th>\n",
+       "      <th>num_muts_count</th>\n",
+       "      <th>count</th>\n",
+       "      <th>number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>6027</td>\n",
+       "      <td>10081</td>\n",
+       "      <td>0.597857</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>328</td>\n",
+       "      <td>10081</td>\n",
+       "      <td>0.032536</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>361</td>\n",
+       "      <td>10081</td>\n",
+       "      <td>0.035810</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>6205</td>\n",
+       "      <td>10264</td>\n",
+       "      <td>0.604540</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>319</td>\n",
+       "      <td>10264</td>\n",
+       "      <td>0.031080</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>296</td>\n",
+       "      <td>10264</td>\n",
+       "      <td>0.028839</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>12232</td>\n",
+       "      <td>20345</td>\n",
+       "      <td>0.601229</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>647</td>\n",
+       "      <td>20345</td>\n",
+       "      <td>0.031801</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>657</td>\n",
+       "      <td>20345</td>\n",
+       "      <td>0.032293</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         library             sample  mutation_type  num_muts_count  count    number\n",
+       "0          lib_1  barcoded variants  nonsynonymous            6027  10081  0.597857\n",
+       "1          lib_1  barcoded variants     synonymous             328  10081  0.032536\n",
+       "2          lib_1  barcoded variants           stop             361  10081  0.035810\n",
+       "3          lib_2  barcoded variants  nonsynonymous            6205  10264  0.604540\n",
+       "4          lib_2  barcoded variants     synonymous             319  10264  0.031080\n",
+       "5          lib_2  barcoded variants           stop             296  10264  0.028839\n",
+       "6  all libraries  barcoded variants  nonsynonymous           12232  20345  0.601229\n",
+       "7  all libraries  barcoded variants     synonymous             647  20345  0.031801\n",
+       "8  all libraries  barcoded variants           stop             657  20345  0.032293"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "variants.numCodonMutsByType('single', samples=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>library</th>\n",
+       "      <th>sample</th>\n",
+       "      <th>mutation_type</th>\n",
+       "      <th>num_muts_count</th>\n",
+       "      <th>count</th>\n",
+       "      <th>number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>45237</td>\n",
+       "      <td>25000</td>\n",
+       "      <td>1.80948</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>2387</td>\n",
+       "      <td>25000</td>\n",
+       "      <td>0.09548</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>2362</td>\n",
+       "      <td>25000</td>\n",
+       "      <td>0.09448</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>44952</td>\n",
+       "      <td>25000</td>\n",
+       "      <td>1.79808</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>2461</td>\n",
+       "      <td>25000</td>\n",
+       "      <td>0.09844</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>2410</td>\n",
+       "      <td>25000</td>\n",
+       "      <td>0.09640</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>90189</td>\n",
+       "      <td>50000</td>\n",
+       "      <td>1.80378</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>4848</td>\n",
+       "      <td>50000</td>\n",
+       "      <td>0.09696</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>barcoded variants</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>4772</td>\n",
+       "      <td>50000</td>\n",
+       "      <td>0.09544</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         library             sample  mutation_type  num_muts_count  count   number\n",
+       "0          lib_1  barcoded variants  nonsynonymous           45237  25000  1.80948\n",
+       "1          lib_1  barcoded variants     synonymous            2387  25000  0.09548\n",
+       "2          lib_1  barcoded variants           stop            2362  25000  0.09448\n",
+       "3          lib_2  barcoded variants  nonsynonymous           44952  25000  1.79808\n",
+       "4          lib_2  barcoded variants     synonymous            2461  25000  0.09844\n",
+       "5          lib_2  barcoded variants           stop            2410  25000  0.09640\n",
+       "6  all libraries  barcoded variants  nonsynonymous           90189  50000  1.80378\n",
+       "7  all libraries  barcoded variants     synonymous            4848  50000  0.09696\n",
+       "8  all libraries  barcoded variants           stop            4772  50000  0.09544"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "variants.numCodonMutsByType('all', samples=None)"
    ]
   },
   {
@@ -752,7 +1022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -822,7 +1092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -919,7 +1189,7 @@
        "4   lib_1  barcoded variants      L5R     21  nonsynonymous     5"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -938,7 +1208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -985,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1019,7 +1289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1078,7 +1348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1102,7 +1372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1137,7 +1407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1194,7 +1464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1228,7 +1498,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1313,7 +1583,7 @@
        "4   lib_1  AAAAAAGATTCCACGT  pre-selection     93"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1334,7 +1604,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1360,7 +1630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1467,7 +1737,7 @@
        "8  all libraries   tight_bottle  10000000"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1498,7 +1768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1613,7 +1883,7 @@
        "4  GGCGGGTTCGACGGCA    724   lib_1  pre-selection                     1                             AAC21AAA TTA47CGC                 N21K L47R                      2                   2"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1638,7 +1908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1673,7 +1943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1719,7 +1989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1759,12 +2029,663 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here are the numerical data plotted above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>library</th>\n",
+       "      <th>sample</th>\n",
+       "      <th>mutation_type</th>\n",
+       "      <th>num_muts_count</th>\n",
+       "      <th>count</th>\n",
+       "      <th>number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>1210701</td>\n",
+       "      <td>2018466</td>\n",
+       "      <td>0.599812</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>67196</td>\n",
+       "      <td>2018466</td>\n",
+       "      <td>0.033291</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>74209</td>\n",
+       "      <td>2018466</td>\n",
+       "      <td>0.036765</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>1784366</td>\n",
+       "      <td>3307103</td>\n",
+       "      <td>0.539556</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>139831</td>\n",
+       "      <td>3307103</td>\n",
+       "      <td>0.042282</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>1085</td>\n",
+       "      <td>3307103</td>\n",
+       "      <td>0.000328</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>1784290</td>\n",
+       "      <td>3312726</td>\n",
+       "      <td>0.538617</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>138351</td>\n",
+       "      <td>3312726</td>\n",
+       "      <td>0.041763</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>989</td>\n",
+       "      <td>3312726</td>\n",
+       "      <td>0.000299</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>1239988</td>\n",
+       "      <td>2056112</td>\n",
+       "      <td>0.603074</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>64011</td>\n",
+       "      <td>2056112</td>\n",
+       "      <td>0.031132</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>57903</td>\n",
+       "      <td>2056112</td>\n",
+       "      <td>0.028161</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>1795231</td>\n",
+       "      <td>3359098</td>\n",
+       "      <td>0.534438</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>133371</td>\n",
+       "      <td>3359098</td>\n",
+       "      <td>0.039704</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>791</td>\n",
+       "      <td>3359098</td>\n",
+       "      <td>0.000235</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>1784290</td>\n",
+       "      <td>3347934</td>\n",
+       "      <td>0.532953</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>127597</td>\n",
+       "      <td>3347934</td>\n",
+       "      <td>0.038112</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>793</td>\n",
+       "      <td>3347934</td>\n",
+       "      <td>0.000237</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>2450689</td>\n",
+       "      <td>4074578</td>\n",
+       "      <td>0.601458</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>131207</td>\n",
+       "      <td>4074578</td>\n",
+       "      <td>0.032201</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>132112</td>\n",
+       "      <td>4074578</td>\n",
+       "      <td>0.032423</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>3579597</td>\n",
+       "      <td>6666201</td>\n",
+       "      <td>0.536977</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>273202</td>\n",
+       "      <td>6666201</td>\n",
+       "      <td>0.040983</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>1876</td>\n",
+       "      <td>6666201</td>\n",
+       "      <td>0.000281</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>3568580</td>\n",
+       "      <td>6660660</td>\n",
+       "      <td>0.535770</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>265948</td>\n",
+       "      <td>6660660</td>\n",
+       "      <td>0.039928</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>1782</td>\n",
+       "      <td>6660660</td>\n",
+       "      <td>0.000268</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          library         sample  mutation_type  num_muts_count    count    number\n",
+       "0           lib_1  pre-selection  nonsynonymous         1210701  2018466  0.599812\n",
+       "1           lib_1  pre-selection     synonymous           67196  2018466  0.033291\n",
+       "2           lib_1  pre-selection           stop           74209  2018466  0.036765\n",
+       "3           lib_1   loose_bottle  nonsynonymous         1784366  3307103  0.539556\n",
+       "4           lib_1   loose_bottle     synonymous          139831  3307103  0.042282\n",
+       "5           lib_1   loose_bottle           stop            1085  3307103  0.000328\n",
+       "6           lib_1   tight_bottle  nonsynonymous         1784290  3312726  0.538617\n",
+       "7           lib_1   tight_bottle     synonymous          138351  3312726  0.041763\n",
+       "8           lib_1   tight_bottle           stop             989  3312726  0.000299\n",
+       "9           lib_2  pre-selection  nonsynonymous         1239988  2056112  0.603074\n",
+       "10          lib_2  pre-selection     synonymous           64011  2056112  0.031132\n",
+       "11          lib_2  pre-selection           stop           57903  2056112  0.028161\n",
+       "12          lib_2   loose_bottle  nonsynonymous         1795231  3359098  0.534438\n",
+       "13          lib_2   loose_bottle     synonymous          133371  3359098  0.039704\n",
+       "14          lib_2   loose_bottle           stop             791  3359098  0.000235\n",
+       "15          lib_2   tight_bottle  nonsynonymous         1784290  3347934  0.532953\n",
+       "16          lib_2   tight_bottle     synonymous          127597  3347934  0.038112\n",
+       "17          lib_2   tight_bottle           stop             793  3347934  0.000237\n",
+       "18  all libraries  pre-selection  nonsynonymous         2450689  4074578  0.601458\n",
+       "19  all libraries  pre-selection     synonymous          131207  4074578  0.032201\n",
+       "20  all libraries  pre-selection           stop          132112  4074578  0.032423\n",
+       "21  all libraries   loose_bottle  nonsynonymous         3579597  6666201  0.536977\n",
+       "22  all libraries   loose_bottle     synonymous          273202  6666201  0.040983\n",
+       "23  all libraries   loose_bottle           stop            1876  6666201  0.000281\n",
+       "24  all libraries   tight_bottle  nonsynonymous         3568580  6660660  0.535770\n",
+       "25  all libraries   tight_bottle     synonymous          265948  6660660  0.039928\n",
+       "26  all libraries   tight_bottle           stop            1782  6660660  0.000268"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "variants.numCodonMutsByType('single')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>library</th>\n",
+       "      <th>sample</th>\n",
+       "      <th>mutation_type</th>\n",
+       "      <th>num_muts_count</th>\n",
+       "      <th>count</th>\n",
+       "      <th>number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>9070808</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>1.814162</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>479008</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.095802</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>472593</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.094519</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>5579846</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>1.115969</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>472227</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.094445</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>12259</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.002452</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>5563693</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>1.112739</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>463751</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.092750</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>lib_1</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>10940</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.002188</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>9006912</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>1.801382</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>491903</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.098381</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>477696</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.095539</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>5439493</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>1.087899</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>487784</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.097557</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>11080</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.002216</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>5450911</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>1.090182</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>488569</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.097714</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>lib_2</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>10587</td>\n",
+       "      <td>5000000</td>\n",
+       "      <td>0.002117</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>18077720</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>1.807772</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>970911</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>0.097091</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>pre-selection</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>950289</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>0.095029</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>11019339</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>1.101934</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>960011</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>0.096001</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>loose_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>23339</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>0.002334</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>nonsynonymous</td>\n",
+       "      <td>11014604</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>1.101460</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>synonymous</td>\n",
+       "      <td>952320</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>0.095232</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>26</th>\n",
+       "      <td>all libraries</td>\n",
+       "      <td>tight_bottle</td>\n",
+       "      <td>stop</td>\n",
+       "      <td>21527</td>\n",
+       "      <td>10000000</td>\n",
+       "      <td>0.002153</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          library         sample  mutation_type  num_muts_count     count    number\n",
+       "0           lib_1  pre-selection  nonsynonymous         9070808   5000000  1.814162\n",
+       "1           lib_1  pre-selection     synonymous          479008   5000000  0.095802\n",
+       "2           lib_1  pre-selection           stop          472593   5000000  0.094519\n",
+       "3           lib_1   loose_bottle  nonsynonymous         5579846   5000000  1.115969\n",
+       "4           lib_1   loose_bottle     synonymous          472227   5000000  0.094445\n",
+       "5           lib_1   loose_bottle           stop           12259   5000000  0.002452\n",
+       "6           lib_1   tight_bottle  nonsynonymous         5563693   5000000  1.112739\n",
+       "7           lib_1   tight_bottle     synonymous          463751   5000000  0.092750\n",
+       "8           lib_1   tight_bottle           stop           10940   5000000  0.002188\n",
+       "9           lib_2  pre-selection  nonsynonymous         9006912   5000000  1.801382\n",
+       "10          lib_2  pre-selection     synonymous          491903   5000000  0.098381\n",
+       "11          lib_2  pre-selection           stop          477696   5000000  0.095539\n",
+       "12          lib_2   loose_bottle  nonsynonymous         5439493   5000000  1.087899\n",
+       "13          lib_2   loose_bottle     synonymous          487784   5000000  0.097557\n",
+       "14          lib_2   loose_bottle           stop           11080   5000000  0.002216\n",
+       "15          lib_2   tight_bottle  nonsynonymous         5450911   5000000  1.090182\n",
+       "16          lib_2   tight_bottle     synonymous          488569   5000000  0.097714\n",
+       "17          lib_2   tight_bottle           stop           10587   5000000  0.002117\n",
+       "18  all libraries  pre-selection  nonsynonymous        18077720  10000000  1.807772\n",
+       "19  all libraries  pre-selection     synonymous          970911  10000000  0.097091\n",
+       "20  all libraries  pre-selection           stop          950289  10000000  0.095029\n",
+       "21  all libraries   loose_bottle  nonsynonymous        11019339  10000000  1.101934\n",
+       "22  all libraries   loose_bottle     synonymous          960011  10000000  0.096001\n",
+       "23  all libraries   loose_bottle           stop           23339  10000000  0.002334\n",
+       "24  all libraries   tight_bottle  nonsynonymous        11014604  10000000  1.101460\n",
+       "25  all libraries   tight_bottle     synonymous          952320  10000000  0.095232\n",
+       "26  all libraries   tight_bottle           stop           21527  10000000  0.002153"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "variants.numCodonMutsByType('all')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Here are mutation frequencies as a function of primary sequence:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1810,7 +2731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1889,7 +2810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -1912,7 +2833,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -2063,7 +2984,7 @@
        "4   lib_1  pre-selection  loose_bottle  AAAAAAGATTCCACGT   -3.389638        0.134772         93          18        666360        1381821          0.5  TCC2GTG ATG32GGG CGC48CTT                      3    S2V M32G R48L                   3"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2087,7 +3008,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -2220,7 +3141,7 @@
        "4   lib_1  pre-selection  loose_bottle        A39* G50S   -9.648782        4.173499        193           0        737374        1529501          0.5                   2"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2247,7 +3168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -2320,7 +3241,7 @@
        "4  TCC2GTG ATG32GGG CGC48CTT    S2V M32G R48L  >=2 nonsynonymous"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2348,7 +3269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -2396,7 +3317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2425,7 +3346,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -2462,7 +3383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -2517,7 +3438,7 @@
        "tight_bottle  0.802  0.797"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2553,7 +3474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2572,7 +3493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -2610,7 +3531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -2665,7 +3586,7 @@
        "tight_bottle  0.783  0.777"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2704,7 +3625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 51,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -2739,7 +3660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 52,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -2774,7 +3695,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 53,
    "metadata": {
     "attributes": {
      "classes": [],
@@ -2821,7 +3742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -2854,7 +3775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -2885,7 +3806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -2918,7 +3839,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Previously it was only possible to plot the average
number of codon variants per site; now the numerical
values can also be obtained as data frame.