### PR TITLE
Make compatible with `pandas` 0.25

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Fixed
 -----
 - Docs /formatting in Jupyter notebooks.
 
+- Fixed bugs that arose when `pandas` updated to 0.25 (related to `groupby` no logner dropping empty categories).
+
 0.1.0
 -----
 Initial release. Ported code from `dms_tools2` and made some improvements.

--- a/dms_variants/codonvarianttable.py
+++ b/dms_variants/codonvarianttable.py
@@ -533,7 +533,8 @@ class CodonVariantTable:
         elif by != 'barcode':
             raise ValueError(f"invalid `by` of {by}")
         df = (df
-              .groupby(['library', 'sample', by] + group_cols)
+              .groupby(['library', 'sample', by] + group_cols,
+                       observed=True)
               .aggregate({'count': 'sum'})
               .reset_index()
               )
@@ -633,7 +634,8 @@ class CodonVariantTable:
             raise ValueError(f"invalid `variant_type` {variant_type}")
 
         return (df
-                .groupby(['library', 'sample'])
+                .groupby(['library', 'sample'],
+                         observed=True)
                 .aggregate({'count': 'sum'})
                 .reset_index()
                 )
@@ -1134,7 +1136,8 @@ class CodonVariantTable:
                                                          ordered=True),
                   num_muts_count=lambda x: x.num_muts * x['count']
                   )
-              .groupby(['library', 'sample', 'mutation_type'])
+              .groupby(['library', 'sample', 'mutation_type'],
+                       observed=True)
               .aggregate({'num_muts_count': 'sum', 'count': 'sum'})
               .reset_index()
               .assign(number=lambda x: x.num_muts_count / x['count'])
@@ -1268,7 +1271,8 @@ class CodonVariantTable:
         df[mut_col] = scipy.clip(df[mut_col], None, max_muts)
 
         df = (df
-              .groupby(['library', 'sample', mut_col])
+              .groupby(['library', 'sample', mut_col],
+                       observed=True)
               .aggregate({'count': 'sum'})
               .reset_index()
               )

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,4 @@ setup(
     platforms='Linux and Mac OS X.',
     packages=['dms_variants'],
     package_dir={'dms_variants': 'dms_variants'},
-)
+    )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,5 +7,7 @@ flake8-import-order
 flake8-comprehensions
 flake8-bugbear
 flake8-print
+# pin pydocstyle <4 untilt his bug fixed
+pydocstyle<4
 nbval
 ipython


### PR DESCRIPTION
Due to some changes in how `groupby` worked with
categorical variables in `pandas` 0.25, things
no longer worked as expected. This fixes that.