### PR TITLE
specify subs col in init `CodonVariantTable`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,9 @@ The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
 Added
 -----
-- `CodonVariant.numCodonMutsByType` method to get numerical values for codon mutations per variant.
+- `CodonVariantTable.numCodonMutsByType` method to get numerical values for codon mutations per variant.
+
+- Can specify names of columns when initializing a `CodonVariantTable`.
 
 Fixed
 -----

--- a/dms_variants/codonvarianttable.py
+++ b/dms_variants/codonvarianttable.py
@@ -53,6 +53,9 @@ class CodonVariantTable:
     extra_cols : list
         Additional columns in `barcode_variant_file` to retain when creating
         `barcode_variant_df` and `variant_count_df` attributes.
+    substitutions_col : str
+        Name of substitutions column in `barcode_variant_file` (use if you
+        want it to be something other than "substitutions").
 
     Attributes
     ----------
@@ -178,7 +181,8 @@ class CodonVariantTable:
         return cvt
 
     def __init__(self, *, barcode_variant_file, geneseq,
-                 substitutions_are_codon=False, extra_cols=None):
+                 substitutions_are_codon=False, extra_cols=None,
+                 substitutions_col='substitutions'):
         """See main class doc string."""
         self.geneseq = geneseq.upper()
         if not re.match(f"^[{''.join(NTS)}]+$", self.geneseq):
@@ -191,7 +195,9 @@ class CodonVariantTable:
         self.aas = collections.OrderedDict([
                 (r, CODON_TO_AA[codon]) for r, codon in self.codons.items()])
 
-        df = pd.read_csv(barcode_variant_file)
+        df = (pd.read_csv(barcode_variant_file)
+              .rename(columns={substitutions_col: 'substitutions'})
+              )
         required_cols = ['library', 'barcode',
                          'substitutions', 'variant_call_support']
         if not set(df.columns).issuperset(set(required_cols)):


### PR DESCRIPTION
Can now specify the name of the substitutions column
in `CodonVariantTable` initialization via
`substitutions_col` if you don't want it to be
"substitutions"