### PR TITLE
updates to .gitignore and test reqs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 !.nojekyll
 
 *.pyc
+*.so
 docs/dms_variants.*
 docs/_build
 

--- a/dms_variants/codonvarianttable.py
+++ b/dms_variants/codonvarianttable.py
@@ -1663,6 +1663,7 @@ class CodonVariantTable:
         ...                 )
         >>> variants._sortCodonMuts('GGA2CGT ATG1GTG')
         'ATG1GTG GGA2CGT'
+
         """
         muts = {}
         for mut in mut_str.upper().split():

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,7 +7,5 @@ flake8-import-order
 flake8-comprehensions
 flake8-bugbear
 flake8-print
-# pin pydocstyle <4 untilt his bug fixed
-pydocstyle<4
 nbval
 ipython


### PR DESCRIPTION
Ignore `*.so` files.

In `test_requirements.txt`, we no longer need to
pin `pydocstyle`.