### PR TITLE
better caching for better pickling of epistasis models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.4.1
+------
+
+Fixed
+++++++
+- The `isplines` module now uses a simple dict-implemented cache rather than `methodtools.lru_cache`. This fixes excess memory usage and allows objects to be pickled.
+
 0.4.0
 --------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Fixed
 ++++++
 - The `isplines` module now uses a simple dict-implemented cache rather than `methodtools.lru_cache`. This fixes excess memory usage and allows objects to be pickled.
 
+- `AbstractEpistasis` internally clears the cache via `__getstate__` to reduce size of pickled objects. This avoids pickled models being huge. Also added the `clearcache` option to `AbstractEpistasis.fit` to serve a similar purpose of memory savings.
+
 0.4.0
 --------
 

--- a/dms_variants/__init__.py
+++ b/dms_variants/__init__.py
@@ -10,5 +10,5 @@ variants of genes.
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 __url__ = 'https://github.com/jbloomlab/dms_variants'

--- a/dms_variants/globalepistasis.py
+++ b/dms_variants/globalepistasis.py
@@ -440,6 +440,15 @@ class AbstractEpistasis(abc.ABC):
         self._likelihood_calc_params = self._init_likelihood_calc_params
         self._epistasis_func_params = self._init_epistasis_func_params
 
+    def __getstate__(self):
+        """Clears the internal `_cache` before pickling.
+
+        See: https://docs.python.org/3/library/pickle.html#object.__getstate__
+
+        """
+        self._cache = {}
+        return self.__dict__
+
     # ------------------------------------------------------------------------
     # Methods / properties to set and get model parameters that are fit.
     # The setters must clear appropriate elements from the cache.
@@ -772,7 +781,8 @@ class AbstractEpistasis(abc.ABC):
     # that store the current state for the variants we are fitting, using the
     # cache so that they don't have to be re-computed needlessly.
     # ------------------------------------------------------------------------
-    def fit(self, *, use_grad=True, optimize_method='L-BFGS-B', ftol=1e-7):
+    def fit(self, *, use_grad=True, optimize_method='L-BFGS-B', ftol=1e-7,
+            clearcache=True):
         """Fit all model params to maximum likelihood values.
 
         Parameters
@@ -784,6 +794,10 @@ class AbstractEpistasis(abc.ABC):
         ftol : float
             Function convergence tolerance for optimization, used by
             `scipy.optimize.minimize`.
+        clearcache : bool
+            Clear the cache after model fitting? This slightly increases
+            the time needed to compute properties after fitting, but
+            greatly saves memory usage.
 
         Returns
         -------
@@ -815,6 +829,9 @@ class AbstractEpistasis(abc.ABC):
 
         # postscale parameters to desired range
         self._postscale_params()
+
+        if clearcache:
+            self._cache = {}
 
         return optres
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     install_requires=[
             'biopython>=1.73',
             'matplotlib>=3.1',
-            'methodtools>=0.1.1',
             'pandas>=0.25.1',
             'plotnine>=0.6',
             'regex>=2.4.153',


### PR DESCRIPTION
The global epistasis models could become very large in terms of memory footprint due to the caching of the I-splines by `methodtools.lru_cache`. In addition, the use of the `methodtools` caching made it impossible to pickle models for storage.

Now the usage of `methodtools` has been eliminated in favor of a simple dict caching implemented within the spline classes. 

In addition, the epistasis models now clear their cache before pickling and (by default but optionally) after fitting. While this slightly increases the time to access results (as some things have to be re-calculated), it reduces memory footprint a lot in a way that should be worth it.

These changes will constitute version 0.4.1.