### PR TITLE
Fix errors using `pandas.query` for ``nan`` values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.4.4
+------
+
+Fixed
+++++++
+- Errors related to using ``pandas.query`` for ``nan`` values. Not sure of the cause, but the errors are fixed now.
+
 0.4.3
 ------
 

--- a/dms_variants/__init__.py
+++ b/dms_variants/__init__.py
@@ -10,5 +10,5 @@ variants of genes.
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 __url__ = 'https://github.com/jbloomlab/dms_variants'

--- a/dms_variants/utils.py
+++ b/dms_variants/utils.py
@@ -359,7 +359,7 @@ def tidy_to_corr(df, sample_col, label_col, value_col, *,
                   value_name='correlation'
                   )
             .rename(columns={sample_col: sample_col + '_1'})
-            .query('not correlation.isna()')
+            .dropna()
             .reset_index(drop=True)
             )
 


### PR DESCRIPTION
Not sure of the cause of this error suddenly cropping up,
but this commit fixes it.

Also, becomes version 0.4.4.