### PR TITLE
added `expand` option to `BinaryMap`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.4.7
+------
+
+Added
++++++
+- The ``expand`` option to ``BinaryMap`` to have maps encode all possible characters at each site.
+
 0.4.6
 -----
 

--- a/dms_variants/__init__.py
+++ b/dms_variants/__init__.py
@@ -10,5 +10,5 @@ variants of genes.
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.4.6'
+__version__ = '0.4.7'
 __url__ = 'https://github.com/jbloomlab/dms_variants'


### PR DESCRIPTION
With this option, the binary maps are no longer "compressed" to just contain observed substitutions relative to wildtype, but rather contain all substitutions at all sites and encode wildtype.