### PR TITLE
remove some unlikely use cases from tests / docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.9.0
+------
+Changed
++++++++
+- Discourage and stop testing multiple latent phenotypes.
+- Remove from docs and stop testing ``predict_variants.ipynb`` as this doesn't seem to be a common use case.
+
 0.8.6
 -----
 Fixed

--- a/dms_variants/__init__.py
+++ b/dms_variants/__init__.py
@@ -10,5 +10,5 @@ variants of genes.
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.8.6'
+__version__ = '0.9.0'
 __url__ = 'https://github.com/jbloomlab/dms_variants'

--- a/dms_variants/globalepistasis.py
+++ b/dms_variants/globalepistasis.py
@@ -113,6 +113,10 @@ and the latent phenotype of the wildtype is set to zero.
 
 Multiple latent phenotypes
 +++++++++++++++++++++++++++
+Although this package allows multiple latent phenotypes, we do **not**
+recommend using them as the models generally do not seem to converge
+in fitting in a useful way with multiple latent phenotypes.
+
 Equations :eq:`latent_phenotype` and :eq:`observed_phenotype` can be
 generalized to the case where multiple latent phenotypes contribute
 to the observed phenotype. Specifically, let there be

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -20,7 +20,6 @@ Below are a series of examples that illustrate usage of this functionality and o
    codonvariant_sim_data
    codonvariant_sim_data_multi_targets
    narrow_bottleneck
-   predict_variants
    codonvariant_plot_formatting
    parsebarcodes_sim_data
 

--- a/docs/predict_variants.nblink
+++ b/docs/predict_variants.nblink
@@ -1,3 +1,0 @@
-{
-    "path": "../notebooks/predict_variants.ipynb"
-}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = dms_variants tests docs notebooks --nbval --ignore setup.py --ignore docs/_build --doctest-modules --doctest-glob='*.rst' --sanitize-with nbval_sanitize.cfg
+addopts = dms_variants tests docs notebooks --nbval --ignore setup.py --ignore docs/_build --ignore notebooks/predict_variants.ipynb --ignore notebooks/multi_latent_phenos.ipynb --doctest-modules --doctest-glob='*.rst' --sanitize-with nbval_sanitize.cfg


### PR DESCRIPTION
Remove the multiple-latent phenotypes notebook from testing (it is slow) and add note that we don't recommend this approach (it doesn't seem to work well).

Remove the predict-variants notebook from docs and testing: it is slow and doesn't seem like a major use case at this point.

Incremented version to 0.9.0 as well, as this will eventually be part of that version.