### PR TITLE
Fix rarefy bcs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.9.1
+-----
+Fixed
++++++
+- Fixed datatype for ``maxpoints`` default in ``barcodes.rarefyBarcodes`` 
+
 0.9.0
 ------
 Changed

--- a/dms_variants/__init__.py
+++ b/dms_variants/__init__.py
@@ -10,5 +10,5 @@ variants of genes.
 
 __author__ = '`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_'
 __email__ = 'jbloom@fredhutch.org'
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 __url__ = 'https://github.com/jbloomlab/dms_variants'

--- a/dms_variants/barcodes.py
+++ b/dms_variants/barcodes.py
@@ -20,7 +20,7 @@ import scipy.special
 
 def rarefyBarcodes(barcodecounts, *,
                    barcodecol='barcode', countcol='count',
-                   maxpoints=1e5, logspace=True):
+                   maxpoints=100000, logspace=True):
     """Rarefaction curve of barcode observations.
 
     Note


### PR DESCRIPTION
Fix error in `maxpoints` default for `rarefyBarcodes` function. Fixes issue #61 